### PR TITLE
Switch over from print statements to actual logging

### DIFF
--- a/bot
+++ b/bot
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+import logging
+from pathlib import Path
+
 from lib import bot
 from lib.cli import Args
 from lib.config import Config
@@ -8,6 +11,17 @@ from lib.config import Config
 def main() -> None:
     args = Args()
     config = Config()
+
+    # TODO: setup the log files to rotate
+    log_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    log_level = log_levels[min(len(log_levels) - 1, args.verbose)]
+    log_file_path = Path("/") / "var" / "log" / "reddit_text_bot.log"
+    logging.basicConfig(
+        format="[%(asctime)s] %(levelname)s: %(message)s",
+        level=log_level,
+        # Log to a log file and stderr
+        handlers=[logging.FileHandler(log_file_path), logging.StreamHandler()],
+    )
 
     bot.run(config, args)
 

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 @dataclass
 class Args:
     dont_comment: bool
+    verbose: int
 
     def __init__(self) -> None:
         parser = ArgumentParser(
@@ -18,7 +19,16 @@ class Args:
             help="Just passively observe all the posts instead of leaving any comments",
             action="store_true",
         )
+        # Default verbosity to INFO
+        parser.add_argument(
+            "--verbose",
+            "-v",
+            help="Increase logging verbosity",
+            action="count",
+            default=1,
+        )
 
         args = parser.parse_args()
 
         self.dont_comment = args.dont_comment
+        self.verbose = args.verbose


### PR DESCRIPTION
Switches the bot over to logging instead of just using `print()`. This logs to stderr (which should work well if running it is converted over to a systemd unit) along with logging to `/var/log/reddit_text_bot.log`

Verbosity defaults to `INFO`, but can set specifically with occurences of the `-v/--verbose` flag